### PR TITLE
Encode

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3 -u
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+"""
+Encode raw text with a trained model. Batches data on-the-fly.
+"""
+
+import numpy as np
+
+import torch as th
+
+from interactive import buffered_read, make_batches
+from fairseq import checkpoint_utils, options, tasks, utils
+
+
+def encode(model, src_tokens, src_lengths):
+    """Encode a batch of sentences"""
+    model.eval()
+    # Run encoder
+    encoder_out = model.encoder(src_tokens, src_lengths=src_lengths)
+    encodings = encoder_out["encoder_out"]
+    # Average along the length dimension (be wary of different lengths)
+    bsz, L = src_tokens.size()
+    src_lengths = src_lengths.float()
+    # Create a mask with 0s where padding tokens are located
+    positions = th.arange(L).view(-1, 1).repeat(1, bsz).float()
+    mask = positions.to(src_lengths.device).lt(src_lengths.view(1, -1))
+    # Multiply by mask and sum over length dimension
+    mean_encodings = th.einsum("lb,lbd->bd", [mask.float(), encodings])
+    # Normalize by respective lengths
+    mean_encodings /= src_lengths.view(-1, 1)
+    # Detach and return
+    return mean_encodings.detach()
+
+
+def main(args):
+    utils.import_user_module(args)
+
+    if args.buffer_size < 1:
+        args.buffer_size = 1
+    if args.max_tokens is None and args.max_sentences is None:
+        args.max_sentences = 1
+
+    assert not args.sampling or args.nbest == args.beam, \
+        '--sampling requires --nbest to be equal to --beam'
+    assert not args.max_sentences or args.max_sentences <= args.buffer_size, \
+        '--max-sentences/--batch-size cannot be larger than --buffer-size'
+
+    print(args)
+
+    use_cuda = th.cuda.is_available() and not args.cpu
+
+    # Setup task, e.g., translation
+    task = tasks.setup_task(args)
+
+    # Load ensemble
+    print('| loading model(s) from {}'.format(args.path))
+    [model], _model_args = checkpoint_utils.load_model_ensemble(
+        args.path.split(':'),
+        arg_overrides=eval(args.model_overrides),
+        task=task,
+    )
+
+    # Optimize ensemble for generation
+    model.make_generation_fast_(
+        beamable_mm_beam_size=None if args.no_beamable_mm else args.beam,
+        need_attn=args.print_alignment,
+    )
+    if args.fp16:
+        model.half()
+    if use_cuda:
+        model.cuda()
+
+    # Hack to support GPT-2 BPE
+    if args.remove_bpe == 'gpt2':
+        from fairseq.gpt2_bpe.gpt2_encoding import get_encoder
+        decoder = get_encoder(
+            'fairseq/gpt2_bpe/encoder.json',
+            'fairseq/gpt2_bpe/vocab.bpe',
+        )
+        def encode_fn(x): return ' '.join(map(str, decoder.encode(x)))
+    else:
+        decoder = None
+        def encode_fn(x): return x
+    # Max position for batching
+    max_positions = utils.resolve_max_positions(
+        task.max_positions(), model.max_positions()
+    )
+    # Prompt
+    if args.buffer_size > 1:
+        print('| Sentence buffer size:', args.buffer_size)
+    print('| Type the input sentence and press return:')
+    start_idx = 0
+    # This tracks all encodings in the order that they are given as input
+    all_encodings = []
+    # Read chunks of the input stream one at a time
+    for inputs in buffered_read(args.input, args.buffer_size):
+        results = []
+        # Make batches on the fly
+        for batch in make_batches(inputs, args, task, max_positions):
+            # Retrieve inputs
+            src_tokens = batch.src_tokens
+            src_lengths = batch.src_lengths
+            if use_cuda:
+                src_tokens = src_tokens.cuda()
+                src_lengths = src_lengths.cuda()
+            # Encode
+            encodings = encode(model, src_tokens, src_lengths)
+            # Save encodings in the correct order
+            # (the batches are out of order to optimize padding)
+            for i, (idx, h) in enumerate(zip(batch.ids.tolist(), encodings)):
+                results.append((start_idx + idx, h))
+        # Save the encodings in order
+        for _, h in sorted(results, key=lambda x: x[0]):
+            all_encodings.append(h.cpu().numpy())
+        # update running id counter
+        start_idx += len(inputs)
+    # Save all encodings to npy
+    np.save(args.output_file, np.stack(all_encodings))
+
+
+def cli_main():
+    parser = options.get_generation_parser(interactive=True)
+    parser.add_argument("--output-file", type=str, required=True)
+    args = options.parse_args_and_arch(parser)
+    main(args)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/fairseq/optim/fairseq_multiobj_sgd.py
+++ b/fairseq/optim/fairseq_multiobj_sgd.py
@@ -1,0 +1,43 @@
+from . import FairseqOptimizer, register_optimizer
+
+from .multiobj_optim import multiobj_optims
+
+
+@register_optimizer('multiobj_sgd')
+class FairseqMultiObjSGD(FairseqOptimizer):
+    def __init__(self, args, params):
+        super().__init__(args, params)
+        name = getattr(args, "multiobj_optim_name", "avg")
+        self.optimizer_config["always_project"] = args.always_project
+        self.optimizer_config["reverse"] = args.reverse_constraint
+        if name in multiobj_optims:
+            self._optimizer = multiobj_optims[name](
+                params, **self.optimizer_config)
+        else:
+            raise ValueError(f"Unknown optimizer {name}")
+
+    @staticmethod
+    def add_args(parser):
+        """Add optimizer-specific arguments to the parser."""
+        parser.add_argument('--multiobj-optim-name',
+                            default='avg', metavar='NAME')
+        parser.add_argument('--always-project', action="store_true")
+        parser.add_argument('--reverse-constraint', action="store_true")
+
+    def save_auxiliary(self):
+        """This saves the gradients wrt. the auxiliary objective"""
+        self.optimizer.save_auxiliary()
+
+    @property
+    def optimizer_config(self):
+        """
+        Return a kwarg dictionary that will be used to override optimizer
+        args stored in checkpoints. This allows us to load a checkpoint and
+        resume training using a different set of optimizer args, e.g., with a
+        different learning rate.
+        """
+        return {
+            'lr': self.args.lr[0],
+            'momentum': self.args.momentum,
+            'weight_decay': self.args.weight_decay,
+        }

--- a/fairseq/optim/multiobj/__init__.py
+++ b/fairseq/optim/multiobj/__init__.py
@@ -1,0 +1,23 @@
+from .multiobj_sgd import MultiObjSGD
+
+multiobj_optims = {}
+
+
+def register_multiobj_optim(name):
+    """Decorator to register a new multiobjective optimizer."""
+
+    def register_multiobj_optim_cls(cls):
+        if name in multiobj_optims:
+            raise ValueError(f"Cannot register duplicate optimizer ({name})")
+        if not issubclass(cls, MultiObjSGD):
+            raise ValueError(f"Optimizer ({name}: {cls.__name__}) "
+                             "must extend FairseqOptimizer")
+        if cls.__name__ in multiobj_optims.values():
+            # We use the optimizer class name as a unique identifier in
+            # checkpoints, so all optimizer must have unique class names.
+            raise ValueError("Cannot register optimizer with duplicate class "
+                             f"name ({cls.__name__})")
+        multiobj_optims[name] = cls
+        return cls
+
+    return register_multiobj_optim_cls

--- a/fairseq/optim/multiobj/multiobj_sgd.py
+++ b/fairseq/optim/multiobj/multiobj_sgd.py
@@ -1,0 +1,277 @@
+import torch as th
+from torch.optim.optimizer import Optimizer, required
+from . import register_multiobj_optim
+
+
+def normalize_param(W):
+    return W / W.norm(2).clamp(min=1e-12)
+
+
+def to_vector(tensors):
+    """Flatten a list of parameters/gradients to a vector"""
+    return th.cat([t.view(-1) for t in tensors])
+
+
+def from_vector(tensors, vector):
+    """Reverse `to_vector` (overwrites the tensor values)"""
+    pointer = 0
+    for tensor in tensors:
+        new_val = vector[pointer:pointer+tensor.numel()].view(tensor.size())
+        tensor.copy_(new_val)
+        pointer += tensor.numel()
+
+
+class MultiObjSGD(Optimizer):
+    """
+    This optimizer works like SGD excepts:
+
+    1. it stores gradient from an auxiliary task with `.save_auxiliary()`
+    2. it uses those auxiliary gradients using `.combine_gradientss()` before
+        applying the update
+
+    Args:
+        full_gradients (bool): do gradient combination ops on the full
+            gradients (as opposed to separately for each parameter)
+    """
+
+    def __init__(self, params, lr=required, momentum=0, dampening=0,
+                 weight_decay=0, nesterov=False, always_project=True,
+                 full_gradients=False):
+        if lr is not required and lr < 0.0:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if momentum < 0.0:
+            raise ValueError("Invalid momentum value: {}".format(momentum))
+        if weight_decay < 0.0:
+            raise ValueError(
+                "Invalid weight_decay value: {}".format(weight_decay))
+
+        defaults = dict(lr=lr, momentum=momentum, dampening=dampening,
+                        weight_decay=weight_decay, nesterov=nesterov,
+                        frozen=False)
+        if nesterov and (momentum <= 0 or dampening != 0):
+            raise ValueError(
+                "Nesterov momentum requires a momentum and zero dampening")
+        super(MultiObjSGD, self).__init__(params, defaults)
+        self.always_project = always_project
+        self.full_gradients = full_gradients
+
+    def __setstate__(self, state):
+        super(MultiObjSGD, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault("nesterov", False)
+
+    def save_auxiliary(self):
+        """This saves the gradients wrt. the auxiliary objective"""
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                # skip frozen parameters (TODO: remove this)
+                if getattr(param_state, "frozen", False):
+                    continue
+                # Actually save the gradient
+                param_state["aux_grad"] = th.zeros_like(p.data)
+                if p.grad is None:
+                    continue
+                d_p = p.grad.data
+                param_state["aux_grad"].add_(d_p)
+
+    def combine_gradients(self, g_p, aux_g_p):
+        """Manipulate the gradient g_p using the gradient from the auxiliary
+        objective aux_g_p"""
+        raise NotImplementedError()
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        # Apply momentum and everything to get final gradient
+        params = []
+        lrs = []
+        grads = []
+        aux_grads = []
+        for group in self.param_groups:
+            weight_decay = group["weight_decay"]
+            momentum = group["momentum"]
+            dampening = group["dampening"]
+            nesterov = group["nesterov"]
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                d_p = p.grad.data
+                if weight_decay != 0:
+                    d_p.add_(weight_decay, p.data)
+
+                param_state = self.state[p]
+                # skip frozen parameters
+                if getattr(param_state, "frozen", False):
+                    print("Skipping parameter of size", p.dim())
+                    continue
+                if momentum != 0:
+                    if "momentum_buffer" not in param_state:
+                        buf = param_state["momentum_buffer"] = th.zeros_like(
+                            p.data)
+                        buf.mul_(momentum).add_(d_p)
+                    else:
+                        buf = param_state["momentum_buffer"]
+                        buf.mul_(momentum).add_(1 - dampening, d_p)
+                    if nesterov:
+                        d_p = d_p.add(momentum, buf)
+                    else:
+                        d_p = buf
+                # Track parameters, learning rate, gradients and auxiliary
+                # gradients
+                params.append(p)
+                lrs.append(param_state["lr"])
+                grads.append(d_p)
+                if "aux_grad" in param_state:
+                    aux_grads.append(param_state["aux_grad"])
+                else:
+                    aux_grads.append(th.zeros_like(d_p))
+
+        # Combine gradients
+        if self.full_gradients:
+            # Consider parameters as one vector
+            new_grad_vec = self.combine_gradients(
+                to_vector(grads),
+                to_vector(aux_grads)
+            )
+            # Overwrite gradients
+            from_vector(grads, new_grad_vec)
+        else:
+            # Treat each parameter independently
+            grads = [self.combine_gradients(g, aux_g)
+                     for g, aux_g in zip(grads, aux_grads)]
+
+        # Apply the update
+        for p, lr, g in zip(params, lrs, grads):
+            p.data.add_(-lr, g)
+
+        return loss
+
+
+@register_multiobj_optim("single")
+class SingleObjSGD(MultiObjSGD):
+    """Same as SGD ("single" objective)"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        return g_p
+
+
+@register_multiobj_optim("avg")
+class AvgMultiObjSGD(MultiObjSGD):
+    """Average the gradients"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        avg_p = 0.5 * (aux_g_p + g_p)
+        return avg_p
+
+
+@register_multiobj_optim("ortho")
+class OrthoMultiObjSGD(MultiObjSGD):
+    """Project the gradient g_p on the hyperplane orthogonal to aux_g_p"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        c_unit = aux_g_p / (aux_g_p.norm(2) + 1e-10)
+        dot = (g_p * c_unit).sum()
+        # Only project if the gradients have negative dot product
+        if self.always_project or dot.data <= 0:
+            return g_p - dot * c_unit
+        else:
+            return g_p
+
+
+@register_multiobj_optim("nullify")
+class NullifyMultiObjSGD(MultiObjSGD):
+    """Nullify the gradient if the directions are not aligned"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        if (g_p * aux_g_p).sum() <= 0:
+            return th.zeros_like(g_p)
+        else:
+            return aux_g_p
+
+
+@register_multiobj_optim("cwise-ortho")
+class CwiseOrthoMultiObjSGD(MultiObjSGD):
+    """Orthogonal projection but at the level of scalar parameters"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        mask = th.nn.functional.relu(th.sign(g_p * aux_g_p))
+        return mask * g_p
+
+
+@register_multiobj_optim("cosine-weighted")
+class CosineWeightedMultiObjSGD(MultiObjSGD):
+    """Weight the update by the (rectified) cosine similarity between the two
+    gradients. Update in the direction of aux_g_p"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        c_unit = aux_g_p / (aux_g_p.norm(2) + 1e-10)
+        g_unit = g_p / (g_p.norm(2) + 1e-10)
+        cosine = (g_unit * c_unit).sum()
+        return th.nn.functional.relu(cosine) * g_p
+
+
+@register_multiobj_optim("cosine-weighted-sum")
+class CosineWeightedSumMultiObjSGD(MultiObjSGD):
+    """Weight the update by the (rectified) cosine similarity between the two
+    gradients. Update in the direction of g_p + aux_g_p
+    (see https://arxiv.org/abs/1812.02224)"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        c_unit = aux_g_p / (aux_g_p.norm(2) + 1e-10)
+        g_unit = g_p / (g_p.norm(2) + 1e-10)
+        cosine = (g_unit * c_unit).sum()
+        return th.nn.functional.relu(cosine) * 0.5 * (g_p + aux_g_p)
+
+
+@register_multiobj_optim("colinear")
+class ColinearMultiObjSGD(MultiObjSGD):
+    """Project g_p on the direction of aux_g_p (when the 2 are colinear)"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        c_unit = aux_g_p / (aux_g_p.norm(2) + 1e-10)
+        dot = (c_unit * g_p).sum()
+        return th.nn.functional.relu(dot) * c_unit
+
+
+@register_multiobj_optim("same-contrib")
+class SameContribMultiObjSGD(MultiObjSGD):
+    """Here the update is a vector d such that
+    Loss_1(x + d) - Loss_1(x) = Loss_2(x + d) - Loss_2(x)"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        diff = g_p - aux_g_p
+        diff_norm = diff.norm(2) + 1e-10
+        diff_unit = diff / diff_norm
+        dot = (g_p * diff_unit).sum()
+        return g_p - dot * diff_unit
+
+
+@register_multiobj_optim("avg-ortho")
+class AvgOrthoMultiObjSGD(MultiObjSGD):
+    """Project g_p on the orthogonal of aux_g_p, and aux_g_p on the orthogonal
+    of g_p, then average"""
+
+    def combine_gradients(self, g_p, aux_g_p):
+        g_norm = g_p.norm(2)+1e-10
+        c_norm = aux_g_p.norm(2)+1e-10
+        dot = (g_p * aux_g_p).sum()
+        if self.always_project or dot.data <= 0:
+            g_unit = g_p / g_norm
+            c_unit = aux_g_p / c_norm
+            g_proj_c = g_p - (g_p * c_unit).sum() * c_unit
+            aux_g_proj_g = aux_g_p - (aux_g_p * g_unit).sum() * g_unit
+            return 0.5 * (g_proj_c + aux_g_proj_g)
+        else:
+            # If the two are somewhat aligned, no need to project
+            return g_p

--- a/fairseq/tasks/multiobj_translation.py
+++ b/fairseq/tasks/multiobj_translation.py
@@ -1,0 +1,53 @@
+from . import register_task
+from .translation import TranslationTask, load_langpair_dataset
+
+
+@register_task('multiobj-translation')
+class MultiObjTranslationTask(TranslationTask):
+
+    def load_dataset(self, split, epoch=0, combine=False, **kwargs):
+        """Load a given dataset split.
+
+        Args:
+            split (str): name of the split (e.g., train, valid, test)
+        """
+
+        # infer langcode
+        src, tgt = self.args.source_lang, self.args.target_lang
+
+        data_paths = self.args.data.split(':')
+        assert len(data_paths) > 0
+        # Load datasets sequentially
+        self.datasets[split] = [
+            load_langpair_dataset(
+                data_path, split, src, self.src_dict, tgt, self.tgt_dict,
+                combine=combine, dataset_impl=self.args.dataset_impl,
+                upsample_primary=self.args.upsample_primary,
+                left_pad_source=self.args.left_pad_source,
+                left_pad_target=self.args.left_pad_target,
+                max_source_positions=self.args.max_source_positions,
+                max_target_positions=self.args.max_target_positions,
+            )
+            for data_path in data_paths
+        ]
+
+    def dataset(self, split, idx=0):
+        """
+        Return a loaded dataset split.
+
+        Args:
+            split (str): name of the split (e.g., train, valid, test)
+            idx (int): Dataset idx (defaults to 0)
+
+        Returns:
+            a :class:`~fairseq.data.FairseqDataset` corresponding to *split*
+        """
+        from fairseq.data import FairseqDataset
+        if split not in self.datasets:
+            raise KeyError('Dataset not loaded: ' + split)
+        if not isinstance(self.datasets[split], FairseqDataset):
+            raise TypeError(
+                'Datasets are expected to be of type FairseqDataset')
+        if idx < 0 or idx >= len(self.args.data):
+            raise ValueError(f'Invalid dataset idx: {idx}')
+        return self.datasets[split][idx]

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -218,7 +218,7 @@ class Trainer(object):
             epoch=epoch,
         )
 
-    def train_step(self, samples, dummy_batch=False, raise_oom=False):
+    def train_step(self, samples, dummy_batch=False, raise_oom=False, update_params=True):
         """Do forward, backward and parameter update."""
         if self._dummy_batch is None:
             self._dummy_batch = samples[0]
@@ -334,6 +334,10 @@ class Trainer(object):
                 'return ntokens and nsentences'
             ).format(self.task.__class__.__name__))
 
+        # Skip update
+        if not update_params:
+            return logging_output
+        
         try:
             # normalize grads by sample size
             if sample_size > 0:

--- a/multiobj_train.py
+++ b/multiobj_train.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+import collections
+import math
+import torch
+
+from fairseq import options, progress_bar, tasks, utils
+from fairseq.data import iterators
+from fairseq.trainer import Trainer
+from fairseq.meters import AverageMeter, StopwatchMeter
+from train import (
+    load_dataset_splits,
+    load_checkpoint,
+    save_checkpoint,
+    validate,
+    get_training_stats,
+)
+
+
+def main(args, init_distributed=False):
+    utils.import_user_module(args)
+
+    assert args.max_tokens is not None or args.max_sentences is not None, \
+        'Must specify batch size either with --max-tokens or --max-sentences'
+
+    # Initialize CUDA and distributed training
+    if torch.cuda.is_available() and not args.cpu:
+        torch.cuda.set_device(args.device_id)
+    torch.manual_seed(args.seed)
+    if init_distributed:
+        args.distributed_rank = distributed_utils.distributed_init(args)
+
+    # Print args
+    print(args)
+
+    # Setup task, e.g., translation, language modeling, etc.
+    task = tasks.setup_task(args)
+
+    # Load valid dataset (we load training data below, based on the latest checkpoint)
+    for valid_sub_split in args.valid_subset.split(','):
+        task.load_dataset(valid_sub_split, combine=False, epoch=0)
+
+    # Build model and criterion
+    model = task.build_model(args)
+    criterion = task.build_criterion(args)
+    print(model)
+    print('| model {}, criterion {}'.format(
+        args.arch, criterion.__class__.__name__))
+    print('| num. model params: {} (num. trained: {})'.format(
+        sum(p.numel() for p in model.parameters()),
+        sum(p.numel() for p in model.parameters() if p.requires_grad),
+    ))
+
+    # Build trainer
+    trainer = Trainer(args, task, model, criterion)
+    print('| training on {} GPUs'.format(args.distributed_world_size))
+    print('| max tokens per GPU = {} and max sentences per GPU = {}'.format(
+        args.max_tokens,
+        args.max_sentences,
+    ))
+
+    # Load the latest checkpoint if one is available and restore the
+    # corresponding train iterator
+    extra_state, epoch_itr = checkpoint_utils.load_checkpoint(args, trainer)
+    
+    # Load auxiliary data
+    epoch_aux_itr = task.get_batch_iterator(
+        dataset=task.dataset(args.train_subset),
+        max_tokens=args.max_tokens,
+        max_sentences=args.max_sentences,
+        max_positions=utils.resolve_max_positions(
+            task.max_positions(),
+            trainer.model.max_positions(),
+        ),
+        ignore_invalid_inputs=True,
+        required_batch_size_multiple=args.required_batch_size_multiple,
+        seed=args.seed,
+        num_shards=args.distributed_world_size,
+        shard_id=args.distributed_rank,
+        num_workers=args.num_workers,
+        epoch=trainer.epoch,
+    )
+
+    # Train until the learning rate gets too small
+    max_epoch = args.max_epoch or math.inf
+    max_update = args.max_update or math.inf
+    lr = trainer.get_lr()
+    train_meter = StopwatchMeter()
+    train_meter.start()
+    valid_losses = [None]
+    valid_subsets = args.valid_subset.split(',')
+    while lr > args.min_lr and epoch_itr.epoch < max_epoch and trainer.get_num_updates() < max_update:
+        # train for one epoch
+        train(args, trainer, task, epoch_itr, epoch_aux_itr)
+
+        if not args.disable_validation and epoch_itr.epoch % args.validate_interval == 0:
+            valid_losses = validate(
+                args, trainer, task, epoch_itr, valid_subsets)
+        else:
+            valid_losses = [None]
+
+        # only use first validation loss to update the learning rate
+        lr = trainer.lr_step(epoch_itr.epoch, valid_losses[0])
+
+        # save checkpoint
+        if epoch_itr.epoch % args.save_interval == 0:
+            checkpoint_utils.save_checkpoint(
+                args, trainer, epoch_itr, valid_losses[0])
+
+        if ':' in getattr(args, 'data', ''):
+            # sharded data: get train iterator for next epoch
+            epoch_itr = trainer.get_train_iterator(epoch_itr.epoch)
+    train_meter.stop()
+    print('| done training in {:.1f} seconds'.format(train_meter.sum))
+
+
+def train(args, trainer, task, epoch_itr, epoch_aux_itr):
+    """Train the model for one epoch."""
+    # Update parameters every N batches
+    update_freq = args.update_freq[epoch_itr.epoch - 1] \
+        if epoch_itr.epoch <= len(args.update_freq) else args.update_freq[-1]
+
+    # Initialize data iterator
+    itr = epoch_itr.next_epoch_itr(
+        fix_batches_to_gpus=args.fix_batches_to_gpus,
+        shuffle=(epoch_itr.epoch >= args.curriculum),
+    )
+    itr = iterators.GroupedIterator(itr, update_freq)
+    progress = progress_bar.build_progress_bar(
+        args, itr, epoch_itr.epoch, no_progress_bar='simple',
+    )
+
+    # Auxiliary iterator
+    aux_itr = epoch_aux_itr.next_epoch_itr(
+        fix_batches_to_gpus=args.fix_batches_to_gpus)
+    aux_itr = iterators.GroupedIterator(
+        aux_itr, update_freq, bottomless=True)
+
+    extra_meters = collections.defaultdict(lambda: AverageMeter())
+    valid_subsets = args.valid_subset.split(',')
+    max_update = args.max_update or math.inf
+    for i, samples in enumerate(progress, start=epoch_itr.iterations_in_epoch):
+        # Record gradients from auxiliary data
+        aux_samples = next(aux_itr)
+        trainer.train_step(aux_samples, update_params=False)
+        # if hasattr(trainer.optimizer, "save_auxiliary"):
+        trainer.optimizer.save_auxiliary()
+
+        log_output = trainer.train_step(samples)
+        if log_output is None:
+            continue
+
+        # log mid-epoch stats
+        stats = get_training_stats(trainer)
+        for k, v in log_output.items():
+            if k in ['loss', 'nll_loss', 'ntokens', 'nsentences', 'sample_size']:
+                continue  # these are already logged above
+            if 'loss' in k:
+                extra_meters[k].update(v, log_output['sample_size'])
+            else:
+                extra_meters[k].update(v)
+            stats[k] = extra_meters[k].avg
+        progress.log(stats, tag='train', step=stats['num_updates'])
+
+        # ignore the first mini-batch in words-per-second calculation
+        if i == 0:
+            trainer.get_meter('wps').reset()
+
+        num_updates = trainer.get_num_updates()
+        if (
+            not args.disable_validation
+            and args.save_interval_updates > 0
+            and num_updates % args.save_interval_updates == 0
+            and num_updates > 0
+        ):
+            valid_losses = validate(
+                args, trainer, task, epoch_itr, valid_subsets)
+            checkpoint_utils.save_checkpoint(
+                args, trainer, epoch_itr, valid_losses[0])
+
+        if num_updates >= max_update:
+            break
+
+    # log end-of-epoch stats
+    stats = get_training_stats(trainer)
+    for k, meter in extra_meters.items():
+        stats[k] = meter.avg
+    progress.print(stats, tag='train', step=stats['num_updates'])
+
+    # reset training meters
+    for k in [
+        'train_loss', 'train_nll_loss', 'wps', 'ups', 'wpb', 'bsz', 'gnorm', 'clip',
+    ]:
+        meter = trainer.get_meter(k)
+        if meter is not None:
+            meter.reset()
+
+
+def train(args, trainer, task, epoch_itr, epoch_aux_itr):
+    """Train the model for one epoch."""
+
+    # Update parameters every N batches
+    if epoch_itr.epoch <= len(args.update_freq):
+        update_freq = args.update_freq[epoch_itr.epoch - 1]
+    else:
+        update_freq = args.update_freq[-1]
+
+    # Initialize data iterator
+    itr = epoch_itr.next_epoch_itr(
+        fix_batches_to_gpus=args.fix_batches_to_gpus)
+    itr = iterators.GroupedIterator(itr, update_freq)
+    progress = progress_bar.build_progress_bar(
+        args, itr, epoch_itr.epoch, no_progress_bar='simple',
+    )
+
+    # Auxiliary iterator
+    aux_itr = epoch_aux_itr.next_epoch_itr(
+        fix_batches_to_gpus=args.fix_batches_to_gpus)
+    aux_itr = iterators.GroupedIterator(
+        aux_itr, update_freq, restart_when_done=True)
+
+    extra_meters = collections.defaultdict(lambda: AverageMeter())
+    first_valid = args.valid_subset.split(',')[0]
+    max_update = args.max_update or math.inf
+    for i, samples in enumerate(progress, start=epoch_itr.iterations_in_epoch):
+        # Record gradients from auxiliary data
+        aux_samples = next(aux_itr)
+        trainer.train_step(aux_samples, update_params=False)
+        # if hasattr(trainer.optimizer, "save_constraints"):
+        trainer.optimizer.save_auxiliary()
+
+        log_output = trainer.train_step(samples)
+        if log_output is None:
+            continue
+
+        # log mid-epoch stats
+        stats = get_training_stats(trainer)
+        for k, v in log_output.items():
+            if k in ['loss', 'nll_loss', 'ntokens', 'nsentences', 'sample_size']:
+                continue  # these are already logged above
+            if 'loss' in k:
+                extra_meters[k].update(v, log_output['sample_size'])
+            else:
+                extra_meters[k].update(v)
+            stats[k] = extra_meters[k].avg
+        progress.log(stats)
+
+        # ignore the first mini-batch in words-per-second calculation
+        if i == 0:
+            trainer.get_meter('wps').reset()
+
+        num_updates = trainer.get_num_updates()
+        if args.save_interval_updates > 0 and num_updates % args.save_interval_updates == 0 and num_updates > 0:
+            valid_losses = validate(
+                args, trainer, task, epoch_itr, [first_valid])
+            save_checkpoint(args, trainer, epoch_itr, valid_losses[0])
+
+        if num_updates >= max_update:
+            break
+
+    # log end-of-epoch stats
+    stats = get_training_stats(trainer)
+    for k, meter in extra_meters.items():
+        stats[k] = meter.avg
+    progress.print(stats)
+
+    # reset training meters
+    for k in [
+        'train_loss', 'train_nll_loss', 'wps', 'ups', 'wpb', 'bsz', 'gnorm', 'clip',
+    ]:
+        meter = trainer.get_meter(k)
+        if meter is not None:
+            meter.reset()
+
+
+def add_multitask_args(parser):
+    mtt_group = parser.add_argument_group("Multitask related arguments")
+    mtt_group.add_argument("--freeze-embeddings", action="store_true",
+                           help="Freeze word embeddings when finetuning")
+    mtt_group.add_argument("--freeze-decoder", action="store_true",
+                           help="Freeze decoder when finetuning")
+
+
+if __name__ == '__main__':
+    parser = options.get_training_parser()
+    add_multitask_args(parser)
+    args = options.parse_args_and_arch(parser)
+
+    if args.distributed_port > 0 or args.distributed_init_method is not None:
+        raise NotImplementedError(
+            "Multitask doesn't support multiprocessing yet")
+        from distributed_train import main as distributed_main
+
+        distributed_main(args)
+    elif args.distributed_world_size > 1:
+        raise NotImplementedError(
+            "Multitask doesn't support multiprocessing yet")
+        from multiprocessing_train import main as multiprocessing_main
+
+        multiprocessing_main(args)
+    else:
+        main(args)


### PR DESCRIPTION
This functions like `fairseq-interactive`, for example:

```bash
cat input_file.txt | \
    python fairseq/encode.py \
    corpora/wmt15_en_fr/data-bin  \
    --path models/en-fr.pt \
    --buffer-size 100 \
    --batch-size 64 \
    --max-tokens 4000 \
    --output-file output_file.npy
```

This will save the average encoding for each sentence in `input_file.txt` as a numpy array in `output_file.npy`.

To give an idea, with my transformer model (embedding size = 512), the encodings for a 1M sentences file weigh 2GB in `.npy` format.

